### PR TITLE
Small change in `insertTavAmp( )`

### DIFF
--- a/R/MetFunctions.R
+++ b/R/MetFunctions.R
@@ -243,8 +243,8 @@ insertTavAmp <- function(met){
     data$meanDayT <- (data$maxt + data$mint) / 2
     mmt <- plyr::ddply(data, "month", function(df) mean(df$meanDayT))
     if (nrow(mmt) != 12) stop("At least 12 months of data is required to generate tav and amp.")
-    met@tav <- max(mmt$V1) - min(mmt$V1)
-    met@amp <- mean(mmt$V1)
+    met@tav <- mean(mmt$V1)
+    met@amp <- max(mmt$V1) - min(mmt$V1)
     return(met)
 }
 


### PR DESCRIPTION
Switched computations for met@tav and met@amp in `insertTavAmp()` because they appear to be inverted.
